### PR TITLE
Remove float to int conversion for all units above MB

### DIFF
--- a/bin/sys-oled
+++ b/bin/sys-oled
@@ -43,7 +43,7 @@ def bytes2human(n):
             value = float(n) / prefix[s]
             if s in ['K', 'M']:
                 return '%d%s' % (int(value), s)
-            else
+            else:
                 return '%.1f%s' % (value, s)
     return "%sB" % n
 

--- a/bin/sys-oled
+++ b/bin/sys-oled
@@ -40,8 +40,8 @@ def bytes2human(n):
         prefix[s] = 1 << (i + 1) * 10
     for s in reversed(symbols):
         if n >= prefix[s]:
-            value = int(float(n) / prefix[s])
-            return '%s%s' % (value, s)
+            value = float(n) / prefix[s]
+            return '%.1f%s' % (value, s)
     return "%sB" % n
 
 
@@ -54,7 +54,7 @@ def cpu_usage():
 
 def mem_usage():
     usage = psutil.virtual_memory()
-    return "mem: %s / %s %.0f%%" \
+    return "mem: %s / %s - %.0f%%" \
         % (bytes2human(usage.used), bytes2human(usage.total), usage.percent)
 
 

--- a/bin/sys-oled
+++ b/bin/sys-oled
@@ -41,7 +41,10 @@ def bytes2human(n):
     for s in reversed(symbols):
         if n >= prefix[s]:
             value = float(n) / prefix[s]
-            return '%.1f%s' % (value, s)
+            if s in ['K', 'M']:
+                return '%d%s' % (int(value), s)
+            else
+                return '%.1f%s' % (value, s)
     return "%sB" % n
 
 


### PR DESCRIPTION
Hi,
As mentioned via Twitter, with these changes, the script generates a more accurate representation of the available RAM and disk usage. I've kept the old behaviour for KB and MB values though, to save some space on the screen.
This is my first time doing a pull request on Github, so sorry in advance if something is missing.